### PR TITLE
Fix Storage List

### DIFF
--- a/[Addon] Noblesse oblige (Ricky&Taludas)/shared_tradingcompany_taludas/data/config/export/main/asset/assets.xml
+++ b/[Addon] Noblesse oblige (Ricky&Taludas)/shared_tradingcompany_taludas/data/config/export/main/asset/assets.xml
@@ -158,7 +158,9 @@
               </Item>
             </Maintenances>
           </Maintenance>
-          <StorageBase />
+          <StorageBase>
+            <ProductStorageList>1999005354</ProductStorageList>
+          </StorageBase>
           <LoadingPier>
             <NumOfPiers>1</NumOfPiers>
             <LoadingSpeed>2</LoadingSpeed>

--- a/[Addon] Noblesse oblige (Ricky&Taludas)/shared_tradingcompany_taludas/modinfo.json
+++ b/[Addon] Noblesse oblige (Ricky&Taludas)/shared_tradingcompany_taludas/modinfo.json
@@ -1,5 +1,5 @@
 {
-  "Version": "1.7",
+  "Version": "1.8",
   "ModID": "Taludas_shared_tradingcompany",
   "DeprecateIds": [],
   "ModDependencies": [


### PR DESCRIPTION
I simply exchanged the Storage List of the FTC to the one of its depots. I feel like the idea of combining storage lists will lead to a compability hell because you need to load after ALL products have added their entries to the default storage list, not only the FTC-relevant ones. 